### PR TITLE
Add a GitHub Actions release system 

### DIFF
--- a/.github/workflows/release-lib.sh
+++ b/.github/workflows/release-lib.sh
@@ -1,0 +1,147 @@
+# Adapted by @tfkls from his work at https://github.com/tfkls/sio2-contest-template
+# This is free and unencumbered software released in the public domain. See <unlicense.org> for more details.
+# vi:ts=2:sw=2:noet:
+
+# THIS MUST BE SOURCED
+# shellcheck shell=bash
+load_release() {
+	rm -rf ./_build/
+	mkdir ./_build/
+	mkdir ./_build/results
+	touch ./_build/status
+	cat >./_build/base-release-notes.md <<EOF
+PDF notes generated from sources on push by a github action.
+Last update: 0000-00-00 00:00:00 +0000 (commit 00000000) <!-- DO NOT EDIT THIS LINE UNLESS YOU KNOW WHAT YOU ARE DOING!!! -->
+
+Currently available PDFs:
+
+<!-- BEGIN_STATUS_TABLE -->
+| Name | Files | Build info |
+|------|-------|------------|
+<!-- END_STATUS_TABLE -->
+EOF
+
+	if ! gh release view pdfs >/dev/null; then
+		gh release create pdfs --title 'PDFs' --notes-file ./_build/base-release-notes.md
+	fi
+
+	gh release view pdfs --json body --jq '.body' >./_build/release-notes.md
+	grep '^Last update:' ./_build/release-notes.md | cut -c 14-38 >./_build/release-time
+	grep '^Last update:' ./_build/release-notes.md | sed -Ee 's/.*?\(commit ([0-9a-f]+)\)/\1/' | tr -cd '0-9a-f\n' >./_build/release-commit
+	RELEASE_TIME=$(cat ./_build/release-time)
+	RELEASE_COMMIT=$(cat ./_build/release-commit)
+
+	if [ "$RELEASE_TIME" = "0000-00-00 00:00:00 +0000" ]; then
+		git fetch --unshallow
+	else
+		git fetch --shallow-since "$RELEASE_TIME"
+	fi
+
+	if [ "$RELEASE_TIME" = "0000-00-00 00:00:00 +0000" ]; then
+		git log --pretty=format:%s | tee ./_build/git-logs
+	else
+		git log "$RELEASE_COMMIT..HEAD" --pretty=format:%s | tee ./_build/git-logs
+	fi
+
+	sed -ne '/BEGIN_STATUS_TABLE/,/END_STATUS_TABLE/p' ./_build/release-notes.md | head -n -1 | tail -n +4 >./_build/release-notes.table
+
+	rm -f ./_build/potential_update
+	touch ./_build/potential_update
+	for dir in *; do
+		[ -d "$dir" ] && [ -f "$dir"/main.tex ] && echo "$dir" >>./_build/potential_update
+	done
+
+	rm -f ./_build/update
+	if ! [ -f './.forced-rebuild' ]; then
+		rm -f ./_build/git-logs-rebuild
+		touch ./_build/git-logs-rebuild
+		grep -ohEi '!rebuild-([a-zA-Z0-9-]*|\*)' ./_build/git-logs >>./_build/git-logs-rebuild || true
+		while IFS= read -r word; do
+			case "$word" in
+			'!rebuild-*')
+				gh release edit pdfs --notes-file ./_build/base-release-notes.md
+				touch './.forced-rebuild'
+				load_release && exit "$?" || exit "$?"
+				;;
+			'!rebuild-'*)
+				dir="${word#!rebuild-}"
+				grep -q "^${dir}$" ./_build/update 2>/dev/null && continue
+				grep -q "^${dir}$" ./_build/potential_update 2>/dev/null || continue
+				echo "$dir" >>./_build/update
+				;;
+			*)
+				# Unreachable, but we don't care
+				true
+				;;
+			esac
+		done <./_build/git-logs-rebuild
+	fi
+
+	while IFS= read -r dir; do
+		[ -z "$dir" ] && continue
+		grep -q "^${dir}$" ./_build/update 2>/dev/null && continue
+		if [ "$RELEASE_COMMIT" = "00000000" ]; then
+			echo "$dir" >>./_build/update
+		elif [ "$RELEASE_COMMIT" = "$(git rev-parse --short HEAD)" ]; then
+			true
+		elif grep "^| ${dir} |" ./_build/release-notes.table; then
+			git diff --quiet "$RELEASE_COMMIT" HEAD ./"$dir" || echo "$dir" >>./_build/update
+		else
+			echo "$dir" >>./_build/update
+		fi
+	done <./_build/potential_update
+
+	[ -f "./_build/update" ] && echo "update=true" >>"$GITHUB_OUTPUT" || echo "update=false" >>"$GITHUB_OUTPUT"
+	touch ./_build/update
+}
+
+save_release() {
+	mv ./_build/release-notes.md ./_build/old-release-notes.md
+	cat >./_build/release-notes.md <<EOF
+PDF notes generated from sources on push by a github action.
+Last update: $(git log HEAD^..HEAD --pretty=format:%ai) (commit $(git rev-parse --short HEAD)) <!-- DO NOT EDIT THIS LINE UNLESS YOU KNOW WHAT YOU ARE DOING!!! -->
+
+Currently available PDFs:
+
+<!-- BEGIN_STATUS_TABLE -->
+| Name | Files | Build info |
+|------|-------|------------|
+EOF
+	RELEASE_TIME=$(cat ./_build/release-time)
+	RELEASE_COMMIT=$(cat ./_build/release-commit)
+	gh release view pdfs --json assets --jq '.assets | map(.name) | .[]' >./_build/old-assets
+
+	rm -f ./_build/generated
+	sort ./_build/potential_update >./_build/generated
+
+	while IFS= read -r dir; do
+		[ -z "$dir" ] && continue
+		if line=$(grep "^| ${dir} |" ./_build/release-notes.table); then
+			BUILD=$(echo "$line" | head -n 1 | cut -d '|' -f 3 | xargs)
+			STATUS=$(echo "$line" | head -n 1 | cut -d '|' -f 4 | xargs)
+		else
+			BUILD="Unknown"
+			STATUS="Last build: Unknown (never built)"
+		fi
+		if grep -q "^${dir}\$" "./_build/update"; then
+			STATUS=$(grep "^${dir}:" ./_build/status | cut -d ':' -f 2)
+			STATUS="Last build: $STATUS (commit $(git rev-parse --short HEAD))<br>Warnings:"
+
+			BUILD="[Build&nbsp;logs](https://github.com/$GH_REPO/releases/download/pdfs/${dir}.log)"
+			gh release upload pdfs "./_build/results/${dir}.log" --clobber
+
+			if [ -f "./_build/results/${dir}.pdf" ]; then
+				BUILD="$BUILD<br>[PDF&nbsp;file](https://github.com/$GH_REPO/releases/download/pdfs/${dir}.pdf)"
+				gh release upload pdfs "./_build/results/${dir}.pdf" --clobber
+			else
+				grep -q "^${dir}.pdf$" ./_build/old-assets && gh release delete-asset pdfs "${dir}.pdf"
+				STATUS="$STATUS<br>\`No PDF file generated.\`"
+			fi
+		fi
+
+		echo "| ${dir} | ${BUILD} | ${STATUS} |" >>./_build/release-notes.md
+	done <./_build/generated
+	echo '<!-- END_STATUS_TABLE -->' >>./_build/release-notes.md
+
+	gh release edit pdfs --latest --notes-file ./_build/release-notes.md
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,125 @@
+# Adapted by @tfkls from his work at https://github.com/tfkls/sio2-contest-template
+# This is free and unencumbered software released in the public domain. See <unlicense.org> for more details.
+
+name: release
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  release:
+    # This is one job to save on checkout/startup time
+    name: Build and release PDFs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Git repository (shallow)
+        uses: actions/checkout@v4
+
+      - name: Fetch release data and deepen repository
+        id: load-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          mkdir -p ~/cache/
+          . ./.github/workflows/release-lib.sh
+          set -x
+          load_release
+
+      - name: Cache LaTeX docker image
+        id: cache
+        if: steps.load-release.outputs.update == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/cache/
+          key: ${{ github.workflow }}-cache
+
+      - name: Download LaTeX docker image
+        if: ${{ steps.cache.outputs.cache-hit != 'true' && steps.load-release.outputs.update == 'true' }}
+        run: |
+          docker pull ghcr.io/xu-cheng/texlive-full:latest
+          docker save -o ~/cache/docker-latex.tar ghcr.io/xu-cheng/texlive-full:latest
+
+      - name: Load cached LaTeX image
+        if: ${{ steps.cache.outputs.cache-hit == 'true' && steps.load-release.outputs.update == 'true' }}
+        run: |
+          docker load -i ~/cache/docker-latex.tar
+
+      - name: Compile the statements and packages
+        uses: xu-cheng/texlive-action@v2
+        if: steps.load-release.outputs.update == 'true'
+        with:
+          docker_image: ghcr.io/xu-cheng/texlive-full:latest
+          run: |
+            #tlmgr update --self
+            # Deps like this over the full scheme are considerably faster, and
+            #   I am too lazy to build and publish my own image just for this.
+            #tlmgr install algorithms algorithmicx minted titlesec epigraph nextpage \
+            #  csquotes enumitem thmtools pgf pgfplots tkz-euclide babel babel-polish \
+            #  graphics xcolor fancyvrb fancyhdr iftex mismath esvect mleftright
+
+            set -ex
+            compile_dir() (
+              set -ex
+              FAIL=
+
+              # Timeout ain't posix but exists on alpine/busybox
+              if timeout 60 ./build-one.sh "${1}" >./"${1}make.log" 2>&1; then
+                true
+              else
+                case "$?" in
+                  124|143)
+                    echo "Timed out"
+                    FAIL="Timeout"
+                    ;;
+                  *)
+                    echo "Failed w/exitcode: $?"
+                    FAIL="Failure"
+                    ;;
+                esac
+              fi
+              [ -f "./build/${1}/main.pdf" ] && mv "./build/${1}/main.pdf" "./_build/results/${1}.pdf"
+
+              # Easy to add extra TeX artifacts if we want to later.
+
+              mv "./${1}make.log" "./_build/results/${1}.log" || exit "$?"
+
+              if [ -n "$FAIL" ]; then
+                echo "Failed to compile ${1}/main.tex. Reason: $FAIL"
+                # Small appends are atomic, so no need to `flock`
+                echo "${dir}:$FAIL" >>./_build/status
+              else
+                echo "Successfully compiled ${1}/main.tex"
+                echo "${dir}:Success" >>./_build/status
+              fi
+            )
+
+            COUNT=0
+            while IFS= read -r dir; do
+              # Had issues with parallelism; disabled for now
+              compile_dir "${dir}" # 2>/dev/null &
+              COUNT=$((COUNT+1))
+              if [ "$COUNT" -ge 4 ]; then
+                for job in $(jobs -p); do
+                  wait "$job" || true
+                done
+                COUNT=0
+              fi
+            done<./_build/update
+            for job in $(jobs -p); do
+              wait "$job" || true
+            done
+
+      - name: Update release assets and notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          . ./.github/workflows/release-lib.sh
+          set -x
+          save_release

--- a/aatl/main.tex
+++ b/aatl/main.tex
@@ -9,7 +9,6 @@
 
 % Please, let's familiarize ourselves with notatki.sty and tcs.sty so that we don't reinvent the wheel
 \usepackage{notatki}
-\usepackage{mismath}
 \fancyhead[L]{\textbf{\textit{AATL}}}
 
 \begin{document}

--- a/build-one.sh
+++ b/build-one.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 export TEXINPUTS="$(readlink -f common):$TEXINPUTS"
 
-mkdir build/${1}
+mkdir -p build/${1}
 cd ${1}
 # Execute command twice to generate table of contents
 pdflatex -interaction=nonstopmode -file-line-error -shell-escape --output-directory=../build/${1} main.tex

--- a/common/license.tex
+++ b/common/license.tex
@@ -1,13 +1,13 @@
 \section*{Licencja}
-    \begin{figure}[h]
-    	\begin{minipage}[c]{0.25\textwidth}
-    		\includegraphics[width=0.7\textwidth]{licencja.png}
-    	\end{minipage}\hfill
-    	\begin{minipage}[c]{0.75\textwidth}
-    		\caption*{
-    			Ten utwór jest dostępny na 
-    			\href{https://creativecommons.org/licenses/by-sa/4.0/}{licencji Creative Commons Uznanie autorstwa
-    			na tych samych warunkach 4.0 Międzynarodowe.}
-    		}
-    	\end{minipage}
-    \end{figure}
+\begin{figure}[h]
+	\begin{minipage}[c]{0.25\textwidth}
+		\includegraphics[width=0.7\textwidth]{licencja.png}
+	\end{minipage}\hfill
+	\begin{minipage}[c]{0.75\textwidth}
+		\caption*{
+			Ten utwór jest dostępny na
+			\href{https://creativecommons.org/licenses/by-sa/4.0/}{licencji Creative Commons Uznanie autorstwa
+				na tych samych warunkach 4.0 Międzynarodowe.}
+		}
+	\end{minipage}
+\end{figure}

--- a/common/notatki.sty
+++ b/common/notatki.sty
@@ -11,7 +11,7 @@
 \usepackage[utf8]{inputenc}
 
 % Math
-\usepackage{amsmath} 
+\usepackage{amsmath}
 \usepackage{amsthm}
 \usepackage{amssymb}
 \usepackage{mathtools}
@@ -19,6 +19,7 @@
 \usepackage[noend]{algpseudocode}
 \usepackage{minted}
 \usepackage{multicol}
+\usepackage{mismath}
 
 % Better links
 \usepackage{hyperref}
@@ -54,9 +55,9 @@
 \fancyhead[RE]{\textbf{\textit{\nouppercase{\leftmark}}}}
 \fancyhead[LO]{\textbf{\textit{\nouppercase{\rightmark}}}}
 \fancypagestyle{plain}{ %
-\fancyhf{} % remove everything
-\renewcommand{\headrulewidth}{0pt} % remove lines as well
-\renewcommand{\footrulewidth}{0pt}}
+	\fancyhf{} % remove everything
+	\renewcommand{\headrulewidth}{0pt} % remove lines as well
+	\renewcommand{\footrulewidth}{0pt}}
 \setcounter{secnumdepth}{4}
 
 \pagestyle{fancy}

--- a/common/tcs.sty
+++ b/common/tcs.sty
@@ -4,8 +4,13 @@
 \usepackage{amsmath}
 
 % Common stuff
+\let\argmax\nothing
 \DeclareMathOperator*{\argmax}{arg\,max}
+
+\let\argmin\nothing
 \DeclareMathOperator*{\argmin}{arg\,min}
+
+\let\sgn\nothing
 \DeclareMathOperator{\sgn}{sgn}
 \let\eps\varepsilon
 
@@ -55,7 +60,10 @@
 
 % Set theory
 \let\set\braces
+
+\let\im\nothing
 \DeclareMathOperator{\im}{im}
+\let\im\nothing
 \DeclareMathOperator{\powerset}{\mathcal{P}}
 \renewcommand{\complement}[1]{\overline{#1}}
 \let\function\rightarrow
@@ -65,10 +73,13 @@
 
 
 % Probability
+\let\prob\nothing
 \DeclareMathOperator{\prob}{P}
 \newcommand{\expected}[1]{\mathbb{E}\brackets{#1}}
+\let\Var\nothing
 \DeclareMathOperator{\Var}{Var}
 \newcommand{\variance}[1]{\Var\brackets{#1}}
+\let\Cov\nothing
 \DeclareMathOperator{\Cov}{Cov}
 \newcommand{\covariance}[2]{\Cov\pars{#1, #2}}
 \newcommand\given[1][]{\:#1\vert\:}
@@ -82,6 +93,7 @@
 \DeclareMathOperator{\Normal}{\mathcal{N}}
 
 % Estimators
+\let\bias\nothing
 \DeclareMathOperator{\bias}{bias}
 \newcommand{\mle}[1]{\widehat #1_{MLE}}
 \newcommand{\map}[1]{\widehat #1_{MAP}}
@@ -134,6 +146,7 @@
 \def\reverse{{}^{-1}}
 \def\lin{{\mathrm{Lin}}}
 \newcommand{\dotpro}[2]{\langle #1, #2 \rangle}
+\let\norm\nothing
 \newcommand{\norm}[1]{\left\Vert #1 \right\Vert}
 
 % TikZ
@@ -158,6 +171,7 @@
 % Turing Machine
 \def\blank{\sqcup}
 
+<<<<<<< Updated upstream
 % Posets
 \providecommand\posetwidth[0]{\text{width}}
 \providecommand\posetheight[0]{\text{height}}


### PR DESCRIPTION
Closes #14.

This is a release system based on work I've previously done trying to compile packages, including their statements written in TeX, for the SIO2 testing system at https://github.com/TFKls/sio2-contest-template and I've adapted it for this repository.

In brief, this action creates a new release in the repository, to which it uploads as assets the generated PDF files and their build logs. It automatically runs on every push to the main branch.

It's not perfect: in fact I'll state upfront, in order of (my perceived) severity, some disadvantages of it:
- It's relatively hacky due to it's abuse of GitHub Releases; it generates a dummy git tag which stays frozen in time and serves no purpose other then the fact that it's required to identify a GitHub release.
- It doesn't work as a CI for new PRs, as it is by nature updating a singular release and trying to hack it further would probably cause further issues. It should however be a good template if somebody who wants to copy it and modify it for CI needs.
- It very rarely breaks and needs to be reset by manually updating the release.

The relative upsides are in turn:
- It's a GitHub Action, so it's both free for public repositories and does not require an additional CI server.
- It's predecessor in the linked repo is reasonably well-tested.
- It automatically caches PDF's and regenerated only the ones which have been changed by the pushed commits. It can be overridden by including !rebuild-<directory> or !rebuild-* for all PDF's, as it may be required in the case of updating the common directory.
- It would stop the littering of the repo with more binary PDF files before it's unreasonably large to pull and contribute to.
- It automatically compiles all directories which have a `main.tex` file directly in them, so it should not need to be modified when new notes are added.
- It is already done :)

Below I've attached an image of how the generated release looks (don't mind the Failure texts, these are caused as with most currenly present notes `pdftex` encounters some error and exits with 1 while still finishing the build; it can be easily changed if we prefer to only say Failure if no PDF is generated): ![secret-suffering demo](https://github.com/user-attachments/assets/1c4975d2-169a-43d4-b5c1-33d8931e7745)