### PR TITLE
Added inputs for other subsufferings

### DIFF
--- a/licencjat/main.tex
+++ b/licencjat/main.tex
@@ -26,26 +26,26 @@ Zawartość rozdziału \ref{sysopy} podchodzi z notatek zadedykowanych domenie p
 \mainmatter
 
 % ROK 1, SEMESTR ZIMOWY
-%\input{chapters/analiza/main}
-%\input{chapters/mfi/main}
+\input{chapters/analiza/main}
+\input{chapters/mfi/main}
 \input{chapters/mai/main}
 %\input{chapters/pp/main}
 
 % ROK 1, SEMESTR LETNI
-%\input{chapters/dyskretna/main}
+\input{chapters/dyskretna/main}
 %\input{chapters/id/main}
 %\input{chapters/oop/main}
 %\input{chapters/mp/main}
 
 % ROK 2, SEMESTR ZIMOWY
 
-%\input{chapters/mpi/main}
+\input{chapters/mpi/main}
 %\input{chapters/asd1/main}
-%\input{chapters/sysopy/main}
+\input{chapters/sysopy/main}
 %\input{chapters/sieci/main}
 
 % ROK 2, SEMESTR LETNI
-%\input{chapters/modele/main}
+\input{chapters/modele/main}
 %\input{chapters/io/main}
 %\input{chapters/pn/main}
 


### PR DESCRIPTION
In the Licencjat Suffering, we had some of `\input`s commented (while there existed appropriate sufferings). It was not that much of a problem when we had an artifact in the `build/` directory (and it contained everything it needed to contain). However, it became a problem when we started automatically creating artifacts based on the source code :sweat_smile:

This PR is meant to address this issue.

Note: in case that CI fails here, we will need to edit some code in the Licencjat Suffering to remove errors that existed in the codebase for a long time.