### PR TITLE
Fix footnote links

### DIFF
--- a/common/notatki.sty
+++ b/common/notatki.sty
@@ -81,6 +81,3 @@
 
 % Import custom commands
 \usepackage{tcs}
-
-% Hyperref must be loaded last for footnote links to work (and it's generally recommended)
-\usepackage{hyperref}

--- a/common/notatki.sty
+++ b/common/notatki.sty
@@ -30,7 +30,6 @@
 %\immediate\write18{rm -f .builddir}
 
 % Better links
-\usepackage{hyperref}
 \usepackage{xr}
 
 % Figures
@@ -82,3 +81,6 @@
 
 % Import custom commands
 \usepackage{tcs}
+
+% Hyperref must be loaded last for footnote links to work (and it's generally recommended)
+\usepackage{hyperref}

--- a/common/tcs.sty
+++ b/common/tcs.sty
@@ -174,7 +174,6 @@
 \def\npspace{\textsc{NPSPACE}}
 \def\exptime{\textsc{EXPTIME}}
 \def\re{\textsc{RE}}
-\def\r{\textsc{R}}
 \newcommand{\reg}[1]{\textsc{REG}_#1}
 \newcommand{\cfl}[1]{\textsc{CFL}_#1}
 \newcommand{\csl}[1]{\textsc{CSL}_#1}
@@ -273,3 +272,9 @@
 }{
 	\end{customframe}
 }
+
+% Hyperref must be loaded last for footnote links to work (and it's generally recommended)
+\usepackage{hyperref}
+% This was a part of the Complexity section above, but
+% for some reason, it must happen after hyperref is loadaed
+\def\r{\textsc{R}}


### PR DESCRIPTION
Footnote links currently don't work, linking to the beginning of the pdf instead of to the footnote. This can be seen, for example, on page 2 of `systemy-operacyjne.pdf`. This is fixed by moving `\usepackage{hyperref}` to the end of `notatki.sty`, which is also generally recommended as a good practice.